### PR TITLE
Correct typo in error warning suppression syntax

### DIFF
--- a/lib/HTML/Lint.pm
+++ b/lib/HTML/Lint.pm
@@ -306,7 +306,7 @@ If you want to turn off all HTML::Lint warnings for a block of code, use
 
 And turn them back on with
 
-    <!-- html-lint all: off -->
+    <!-- html-lint all: on -->
 
 You don't have to use "on" and "off".  For "on", you can use "true"
 or "1".  For "off", you can use "0" or "false".


### PR DESCRIPTION
The POD for the module says:

```
[warning suppression docs]
And turn them back on with

<!-- html-lint all: off -->
```

This should be

```
<!-- html-lint all: on -->
```